### PR TITLE
config-store: Add CompoundConfigStore

### DIFF
--- a/test/commands/generate.spec.ts
+++ b/test/commands/generate.spec.ts
@@ -74,6 +74,9 @@ describe('generate', () => {
 
 	it('should generate a Frame from a valid product repo (docker-compose)', async () => {
 		expect(outputDir).to.not.equal('');
+
+		process.env.GENERATE_TEST = 'value_from_env';
+
 		await Generate.run([
 			'-e',
 			configDir,
@@ -87,6 +90,9 @@ describe('generate', () => {
 		for (const file of ['docker-compose/docker-compose.yml']) {
 			const filePath = path.join(outputDir, file);
 			expect(await fs.exists(filePath)).to.equal(true);
+
+			const content = await fs.readFile(filePath, 'utf8');
+			expect(content).contains('value_from_env');
 		}
 	});
 });

--- a/test/components/config-manager.spec.ts
+++ b/test/components/config-manager.spec.ts
@@ -87,7 +87,7 @@ describe('config-manager', async () => {
 		// Ensure the config map is synced
 		const configMap = await configManager.sync();
 
-		expect(configMap).to.have.keys(
+		expect(configMap).to.include.keys(
 			'BALENA_TLD',
 			'BALENA_DEVICE_UUID',
 			'PRODUCTION_MODE',

--- a/test/files/test-product-staging/product/config-manifest.yml
+++ b/test/files/test-product-staging/product/config-manifest.yml
@@ -16,3 +16,5 @@ properties:
   JSON_WEB_TOKEN_SECRET:
     type: string
     pattern: ^[0-9A-Za-z_]{16,64}$
+  GENERATE_TEST:
+    type: string?

--- a/test/files/test-product-staging/product/deploy/docker-compose/templates/docker-compose.yml
+++ b/test/files/test-product-staging/product/deploy/docker-compose/templates/docker-compose.yml
@@ -7,3 +7,4 @@ services:
       BALENA_TLD: {{BALENA_TLD}}
       DOCKER_HOST: {{{DOCKER_HOST}}}
       WEB_TOKEN_BASE64: {{#base64}}{{{JSON_WEB_TOKEN_SECRET}}}{{/base64}}
+      GENERATE_TEST: {{{GENERATE_TEST}}}


### PR DESCRIPTION
A `CompoundConfigStore` can query and update multiple `ConfigStore`'s in order to allow multiple sources of configuration for a product. It is used by default to provide the process runtime environment as a soure, as well as the statically defined source for the product.

Change-type: patch
Signed-off-by: Rich Bayliss <rich@balena.io>
Connects-to: #37